### PR TITLE
Add support for Webpa api version in configuration

### DIFF
--- a/config/sample_webconfig.conf
+++ b/config/sample_webconfig.conf
@@ -24,6 +24,7 @@ webconfig {
         max_idle_conns_per_host = 100
         keepalive_timeout_in_secs = 30
         host = "https://api.example.com"
+        apiVersion = "v2"
     }
 
     codebig2 {

--- a/http/webconfig_server.go
+++ b/http/webconfig_server.go
@@ -325,7 +325,8 @@ func (s *WebconfigServer) NotLoggedHeaders() []string {
 }
 
 func (c *WebconfigServer) Poke(cpeMac string, token string, fields log.Fields) (string, error) {
-	transactionId, err := c.Patch(cpeMac, token, PokeBody, fields)
+	apiVersion := c.Config.GetString("webconfig.webpa.apiVersion", "v2")
+	transactionId, err := c.Patch(cpeMac, token, PokeBody, fields, apiVersion)
 	if err != nil {
 		return "", common.NewError(err)
 	}

--- a/http/webpa_connector.go
+++ b/http/webpa_connector.go
@@ -31,7 +31,7 @@ import (
 const (
 	defaultWebpaHost = "https://api.example.com"
 	webpaServiceName = "webpa"
-	webpaUrlTemplate = "%s/api/v2/device/mac:%s/config"
+	webpaUrlTemplate = "%s/api/%s/device/mac:%s/config"
 	satUrlBase       = "https://token.example.com/oauth/token"
 	webpaError404    = `{"code": 521, "message": "Device not found in webpa"}`
 	webpaError520    = `{"code": 520, "message": "Error unsupported namespace"}`
@@ -64,8 +64,8 @@ func (c *WebpaConnector) SetWebpaHost(host string) {
 	c.host = host
 }
 
-func (c *WebpaConnector) Patch(cpeMac string, token string, bbytes []byte, fields log.Fields) (string, error) {
-	url := fmt.Sprintf(webpaUrlTemplate, c.WebpaHost(), cpeMac)
+func (c *WebpaConnector) Patch(cpeMac string, token string, bbytes []byte, fields log.Fields, apiVersion string) (string, error) {
+	url := fmt.Sprintf(webpaUrlTemplate, c.WebpaHost(), apiVersion, cpeMac)
 
 	var traceId string
 	if itf, ok := fields["trace_id"]; ok {


### PR DESCRIPTION
The latest WebPA version being used is "v3". There is also a previousApiVersion support in Webpa which allows configuring which apiVersion will be used. 
In the same way, Webpa apiVersion can be added to the WebConfig configuration so that it is compatible with different versions of Webpa.