### PR TITLE
Fine grained control for traces

### DIFF
--- a/config/sample_webconfig.conf
+++ b/config/sample_webconfig.conf
@@ -14,6 +14,11 @@ webconfig {
         // "http" will use otlphttpTracer and output spans that need to be collected by otelcollector
         provider = "noop"
         env_name = "dev"
+        // trace_post and trace_patch are flags that enable/disable instrumentation on child calls from oswebconfig
+        // trace_post is for requests to mqtt/upstream
+        trace_post = true
+        // trace_patch is for requests to webpa
+        trace_patch = true
     }
 
     // build info

--- a/http/mqtt_connector.go
+++ b/http/mqtt_connector.go
@@ -45,8 +45,9 @@ func NewMqttConnector(conf *configuration.Config, tlsConfig *tls.Config) *MqttCo
 	confKey := fmt.Sprintf("webconfig.%v.host", serviceName)
 	host := conf.GetString(confKey, mqttHostDefault)
 
+	genTrace := conf.GetBoolean("webconfig.opentelemetry.trace_post", false)
 	return &MqttConnector{
-		HttpClient:  NewHttpClient(conf, serviceName, tlsConfig),
+		HttpClient:  NewHttpClient(conf, serviceName, tlsConfig, genTrace),
 		host:        host,
 		serviceName: serviceName,
 	}

--- a/http/upstream_connector.go
+++ b/http/upstream_connector.go
@@ -47,8 +47,9 @@ func NewUpstreamConnector(conf *configuration.Config, tlsConfig *tls.Config) *Up
 	confKey = fmt.Sprintf("webconfig.%v.url_template", serviceName)
 	upstreamUrlTemplate := conf.GetString(confKey, upstreamUrlTemplateDefault)
 
+	genTrace := conf.GetBoolean("webconfig.opentelemetry.trace_post", false)
 	return &UpstreamConnector{
-		HttpClient:          NewHttpClient(conf, serviceName, tlsConfig),
+		HttpClient:          NewHttpClient(conf, serviceName, tlsConfig, genTrace),
 		host:                host,
 		serviceName:         serviceName,
 		upstreamUrlTemplate: upstreamUrlTemplate,

--- a/http/webpa_connector.go
+++ b/http/webpa_connector.go
@@ -130,9 +130,10 @@ func NewWebpaConnector(conf *configuration.Config, tlsConfig *tls.Config) *Webpa
 	confKey = fmt.Sprintf("webconfig.%v.retry_in_msecs", webpaServiceName)
 	retryInMsecs := int(conf.GetInt32(confKey, defaultRetriesInMsecs))
 
-	syncClient := NewHttpClient(conf, webpaServiceName, tlsConfig)
+	genTrace := conf.GetBoolean("webconfig.opentelemetry.trace_patch", false)
+	syncClient := NewHttpClient(conf, webpaServiceName, tlsConfig, genTrace)
 	syncClient.SetStatusHandler(520, syncHandle520)
-	asyncClient := NewHttpClient(conf, asyncWebpaServiceName, tlsConfig)
+	asyncClient := NewHttpClient(conf, asyncWebpaServiceName, tlsConfig, genTrace)
 	asyncClient.SetStatusHandler(520, asyncHandle520)
 
 	confKey = fmt.Sprintf("webconfig.%v.api_version", webpaServiceName)

--- a/http/xconf_connector.go
+++ b/http/xconf_connector.go
@@ -44,7 +44,8 @@ func NewXconfConnector(conf *configuration.Config, tlsConfig *tls.Config) *Xconf
 	host := conf.GetString(confKey, xconfHostDefault)
 
 	return &XconfConnector{
-		HttpClient:  NewHttpClient(conf, serviceName, tlsConfig),
+		// last param indicates no traces to be generated
+		HttpClient:  NewHttpClient(conf, serviceName, tlsConfig, false),
 		host:        host,
 		serviceName: serviceName,
 	}


### PR DESCRIPTION
We currently generate traces for all calls from osewebconfig to other microservices.
Disable traces for GET calls completely
Flags to control traces for POST/PATCH