### PR TITLE
Narrower Tracing

### DIFF
--- a/config/sample_webconfig.conf
+++ b/config/sample_webconfig.conf
@@ -14,11 +14,6 @@ webconfig {
         // "http" will use otlphttpTracer and output spans that need to be collected by otelcollector
         provider = "noop"
         env_name = "dev"
-        // trace_post and trace_patch are flags that enable/disable instrumentation on child calls from oswebconfig
-        // trace_post is for requests to mqtt/upstream
-        trace_post = true
-        // trace_patch is for requests to webpa
-        trace_patch = true
     }
 
     // build info

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -37,7 +37,6 @@ import (
 	"github.com/go-akka/configuration"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 const (
@@ -63,8 +62,7 @@ type HttpClient struct {
 	userAgent            string
 }
 
-// genTrace is a bool that indicates enabling otel or not
-func NewHttpClient(conf *configuration.Config, serviceName string, tlsConfig *tls.Config, genTrace bool) *HttpClient {
+func NewHttpClient(conf *configuration.Config, serviceName string, tlsConfig *tls.Config) *HttpClient {
 	confKey := fmt.Sprintf("webconfig.%v.connect_timeout_in_secs", serviceName)
 	connectTimeout := int(conf.GetInt32(confKey, defaultConnectTimeout))
 
@@ -95,12 +93,6 @@ func NewHttpClient(conf *configuration.Config, serviceName string, tlsConfig *tl
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig:       tlsConfig,
-	}
-	if genTrace {
-		transport = otelhttp.NewTransport(transport,
-			otelhttp.WithPropagators(otelTracer.propagator),
-			otelhttp.WithTracerProvider(otelTracer.tracerProvider),
-		)
 	}
 
 	return &HttpClient{

--- a/http/mqtt_connector.go
+++ b/http/mqtt_connector.go
@@ -45,9 +45,8 @@ func NewMqttConnector(conf *configuration.Config, tlsConfig *tls.Config) *MqttCo
 	confKey := fmt.Sprintf("webconfig.%v.host", serviceName)
 	host := conf.GetString(confKey, mqttHostDefault)
 
-	genTrace := conf.GetBoolean("webconfig.opentelemetry.trace_post", false)
 	return &MqttConnector{
-		HttpClient:  NewHttpClient(conf, serviceName, tlsConfig, genTrace),
+		HttpClient:  NewHttpClient(conf, serviceName, tlsConfig),
 		host:        host,
 		serviceName: serviceName,
 	}

--- a/http/poke_handler.go
+++ b/http/poke_handler.go
@@ -156,7 +156,7 @@ func (s *WebconfigServer) PokeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	transactionId, err := s.Poke(mac, token, pokeStr, fields)
+	transactionId, err := s.Poke(r.Context(), mac, token, pokeStr, fields)
 	if err != nil {
 		var rherr common.RemoteHttpError
 		if errors.As(err, &rherr) {

--- a/http/upstream_connector.go
+++ b/http/upstream_connector.go
@@ -47,9 +47,8 @@ func NewUpstreamConnector(conf *configuration.Config, tlsConfig *tls.Config) *Up
 	confKey = fmt.Sprintf("webconfig.%v.url_template", serviceName)
 	upstreamUrlTemplate := conf.GetString(confKey, upstreamUrlTemplateDefault)
 
-	genTrace := conf.GetBoolean("webconfig.opentelemetry.trace_post", false)
 	return &UpstreamConnector{
-		HttpClient:          NewHttpClient(conf, serviceName, tlsConfig, genTrace),
+		HttpClient:          NewHttpClient(conf, serviceName, tlsConfig),
 		host:                host,
 		serviceName:         serviceName,
 		upstreamUrlTemplate: upstreamUrlTemplate,

--- a/http/webpa_connector.go
+++ b/http/webpa_connector.go
@@ -130,10 +130,9 @@ func NewWebpaConnector(conf *configuration.Config, tlsConfig *tls.Config) *Webpa
 	confKey = fmt.Sprintf("webconfig.%v.retry_in_msecs", webpaServiceName)
 	retryInMsecs := int(conf.GetInt32(confKey, defaultRetriesInMsecs))
 
-	genTrace := conf.GetBoolean("webconfig.opentelemetry.trace_patch", false)
-	syncClient := NewHttpClient(conf, webpaServiceName, tlsConfig, genTrace)
+	syncClient := NewHttpClient(conf, webpaServiceName, tlsConfig)
 	syncClient.SetStatusHandler(520, syncHandle520)
-	asyncClient := NewHttpClient(conf, asyncWebpaServiceName, tlsConfig, genTrace)
+	asyncClient := NewHttpClient(conf, asyncWebpaServiceName, tlsConfig)
 	asyncClient.SetStatusHandler(520, asyncHandle520)
 
 	confKey = fmt.Sprintf("webconfig.%v.api_version", webpaServiceName)
@@ -167,6 +166,11 @@ func (c *WebpaConnector) ApiVersion() string {
 
 func (c *WebpaConnector) SetApiVersion(apiVersion string) {
 	c.apiVersion = apiVersion
+}
+
+func (c *WebpaConnector) PokeSpanName() string {
+	// By convention, span name won't have the host, but only the base template
+	return fmt.Sprintf(webpaUrlTemplate[2:], c.apiVersion)
 }
 
 func (c *WebpaConnector) NewQueue(capacity int) error {

--- a/http/xconf_connector.go
+++ b/http/xconf_connector.go
@@ -44,8 +44,7 @@ func NewXconfConnector(conf *configuration.Config, tlsConfig *tls.Config) *Xconf
 	host := conf.GetString(confKey, xconfHostDefault)
 
 	return &XconfConnector{
-		// last param indicates no traces to be generated
-		HttpClient:  NewHttpClient(conf, serviceName, tlsConfig, false),
+		HttpClient:  NewHttpClient(conf, serviceName, tlsConfig),
 		host:        host,
 		serviceName: serviceName,
 	}


### PR DESCRIPTION
Add a span specifically for the webpa poke call instead of instrumenting the http client for webpa

This doesn't make a difference as of now as the http client for webpa makes just the poke call; but would be safer for the future.