### PR TITLE
Otel: Explicity add method and status_code as attributes

### DIFF
--- a/http/router.go
+++ b/http/router.go
@@ -91,7 +91,6 @@ func (s *WebconfigServer) GetRouter(testOnly bool) *mux.Router {
 	sub1.HandleFunc("", s.DeleteSubDocumentHandler).Methods("DELETE")
 
 	sub2 := router.Path("/api/v1/device/{mac}/poke").Subrouter()
-	sub2.Use(s.spanMiddleware)
 	if testOnly {
 		sub2.Use(s.TestingMiddleware)
 	} else {
@@ -101,6 +100,7 @@ func (s *WebconfigServer) GetRouter(testOnly bool) *mux.Router {
 			sub2.Use(s.NoAuthMiddleware)
 		}
 	}
+	sub2.Use(s.spanMiddleware)
 	sub2.HandleFunc("", s.PokeHandler).Methods("POST")
 
 	sub3 := router.Path("/api/v1/device/{mac}/rootdocument").Subrouter()


### PR DESCRIPTION
When httpClient was instrumented, these two attributes were automatically added to the spans. Now that we are explicitly adding the span in code, these attributes too need to be added.